### PR TITLE
create log dir

### DIFF
--- a/recipes/_package.rb
+++ b/recipes/_package.rb
@@ -58,3 +58,11 @@ user service_user do
   shell '/bin/false'
   action [:create, :lock]
 end
+
+# create the log directory
+directory node['memcached']['logfilepath'] do
+  owner 'memcache'
+  group 'memcache'
+  mode '0755'
+end
+

--- a/recipes/_package.rb
+++ b/recipes/_package.rb
@@ -65,4 +65,3 @@ directory node['memcached']['logfilepath'] do
   group 'memcache'
   mode '0755'
 end
-


### PR DESCRIPTION
This creates the log directory using attribute `node['memcached']['logfilepath']`. Original cookbook provided's support for log dir customization appears broken.